### PR TITLE
Check descriptions before plugin matching

### DIFF
--- a/che/main.py
+++ b/che/main.py
@@ -134,9 +134,10 @@ def check_if_plugin_call(prompt):
                 store = pickle.load(f)
                 description = store.similarity_search_with_score(prompt, k=1)[0]
                 descriptions.append(description)
-    top_match = sorted(descriptions, key=lambda x: x[1])[0]
-    if top_match[1] < THRESHOLD:
-        return top_match[0].metadata["plugin_name"], top_match[0].metadata["plugin_type"]
+    if(descriptions):
+        top_match = sorted(descriptions, key=lambda x: x[1])[0]
+        if top_match[1] < THRESHOLD:
+            return top_match[0].metadata["plugin_name"], top_match[0].metadata["plugin_type"]
     return None, None
 
 


### PR DESCRIPTION
To avoid the following error when no files in data directory:
```bash
root@67a4fb581e40:/che-sandbox# che "hola"
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /che-sandbox/che/main.py:48 in main                                                              │
│                                                                                                  │
│    45 │                                                                                          │
│    46 │   is_user_satisfied = None                                                               │
│    47 │   plugin_name = None                                                                     │
│ ❱  48 │   plugin_name, plugin_type = check_if_plugin_call(prompt)                                │
│    49 │                                                                                          │
│    50 │   if plugin_type == "executable":                                                        │
│    51 │   │   # Call OpenAI API with the plugin path, description and prompt to get the comman   │
│                                                                                                  │
│ ╭────────── locals ──────────╮                                                                   │
│ │       gen_plugins = False  │                                                                   │
│ │ is_user_satisfied = None   │                                                                   │
│ │       plugin_name = None   │                                                                   │
│ │            prompt = 'hola' │                                                                   │
│ ╰────────────────────────────╯                                                                   │
│                                                                                                  │
│ /che-sandbox/che/main.py:141 in check_if_plugin_call                                             │
│                                                                                                  │
│   138 │   │   │   │   description = store.similarity_search_with_score(prompt, k=1)[0]           │
│   139 │   │   │   │   descriptions.append(description)                                           │
│   140 │   # if(descriptions):                                                                    │
│ ❱ 141 │   top_match = sorted(descriptions, key=lambda x: x[1])[0]                                │
│   142 │   if top_match[1] < THRESHOLD:                                                           │
│   143 │   │   return top_match[0].metadata["plugin_name"], top_match[0].metadata["plugin_type"   │
│   144 │   return None, None                                                                      │
│                                                                                                  │
│ ╭─────── locals ────────╮                                                                        │
│ │ descriptions = []     │                                                                        │
│ │       prompt = 'hola' │                                                                        │
│ ╰───────────────────────╯                                                                        │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
IndexError: list index out of range
```